### PR TITLE
rename `translate`

### DIFF
--- a/raptus/multilanguagefields/skins/multilanguagefields/multiplier.pt
+++ b/raptus/multilanguagefields/skins/multilanguagefields/multiplier.pt
@@ -11,13 +11,13 @@
     <metal:define define-macro="tabs"
                   tal:define="translator python: (widget_name in ('lines', 'keyword', 'rich', 'string', 'textarea')) and (' hasTranslator ' + widget_name) or '';
                               languages python:field.getAvailableLanguages(context);
-                              translate python:len(languages) > 1">
+                              multilanguage python:len(languages) > 1">
       <div class="languageMultiplier"
-           tal:omit-tag="not: translate"
+           tal:omit-tag="not: multilanguage"
            tal:attributes="class string:languageMultiplier${translator}">
       <metal:use use-macro="field_macro | here/widgets/field/macros/edit">
         <dl metal:fill-slot="widget_body"
-            tal:omit-tag="not: translate"
+            tal:omit-tag="not: multilanguage"
             class="enableFormTabbing"
             tal:define="fName fieldName;
                         field_macro here/multilanguage_widgets/field/macros/edit;">
@@ -28,9 +28,9 @@
                            value python:getMethod and getMethod(lang=lang['name']);
                            value python:widget.postback and request.get(fieldName, here.session_restore_value(fieldName, value)) or value;">
           <dt tal:attributes="id string:fieldsetlegend-${fName}-${lang/name}" tal:content="lang/title"
-              tal:condition="translate">Language</dt>
+              tal:condition="multilanguage">Language</dt>
           <dd tal:attributes="id string:fieldset-${fName}-${lang/name}"
-              tal:omit-tag="not: translate">
+              tal:omit-tag="not: multilanguage">
             <div metal:use-macro="python: path('widget_macro|here/widgets/%s/macros/edit' % widget_name)" />
           </dd>
           </tal:def>


### PR DESCRIPTION
`translate` keyword is protected by i18n in TAL. Chameleon Engine (five.pt) does not tolerate overriding such keywords.
